### PR TITLE
Updated system.json with tokens to allow autoupdating during build

### DIFF
--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
   "id": "ironclaw2e",
   "title": "Ironclaw Second Edition",
   "description": "Ironclaw Second Edition system for FoundryVTT.",
-  "version": "0.8.1",
+  "version": "#{VERSION}#",
   "minimumCoreVersion": "11",
   "compatibility": {
     "minimum": "11",
@@ -60,8 +60,8 @@
   "secondaryTokenAttribute": "null",
   "url": "https://github.com/Hertzila/Ironclaw2E-FoundryVTT-System",
   "changelog": "https://github.com/Hertzila/Ironclaw2E-FoundryVTT-System/blob/master/CHANGELOG.md",
-  "manifest": "auto-filled",
-  "download": "auto-filled",
+  "manifest": "#{MANIFEST}#",
+  "download": "#{DOWNLOAD}#",
   "license": "LICENSE",
   "readme": "README.md"
 }

--- a/system.json
+++ b/system.json
@@ -9,6 +9,7 @@
     "minimum": "11",
     "verified": "12.330"
   },
+  "templateVersion": 32,
   "authors": [
     {
       "name": "Hertzila",

--- a/system.json
+++ b/system.json
@@ -9,7 +9,6 @@
     "minimum": "11",
     "verified": "12.330"
   },
-  "templateVersion": 32,
   "authors": [
     {
       "name": "Hertzila",


### PR DESCRIPTION
The auto-replacement of the manifest & download did not work for build v0.8.1.  I replaced some of the values with tokens after looking at the build logs and it seemed to want different output than what was in there. I did a test build on my fork and I can confirm that the version, manifest, and download values now are populated correctly.

![image](https://github.com/user-attachments/assets/c8ccd7a4-eb09-4797-ba7e-db4f155bb64f)
