### PR TITLE
Changes for Diceroller API changes

### DIFF
--- a/module/dicerollers.js
+++ b/module/dicerollers.js
@@ -117,7 +117,7 @@ export class CardinalDiceRoller {
      * @returns {Promise<DiceReturn>} Promise of the roll and the message object or data (depending on sendinchat, true | false) in an object
      */
     static async copyToRollTN(tni, message, sendinchat = true, rerolltype = "", copyoptions = {}) {
-        if (!(message) || message.type !== CONST.CHAT_MESSAGE_TYPES.ROLL) {
+        if (!(message) || !(message.isRoll)) {
             console.warn("Somehow, a message that isn't a roll got into 'copyToRollTN'.");
             console.warn(message);
             return;
@@ -128,9 +128,11 @@ export class CardinalDiceRoller {
             return;
         }
 
-        const usedSpeaker = (copyoptions.replacespeaker ? { "alias": (message.speaker?.alias ?? game.i18n.localize("ironclaw2e.chatInfo.miniRoll")) } : message.speaker);
+        
+		const usedSpeaker = (copyoptions.replacespeaker ? { "alias": (message.speaker?.alias ?? game.i18n.localize("ironclaw2e.chatInfo.miniRoll")) } : message.speaker);
         let intermediary = [...message.getFlag("ironclaw2e", "rollIntermediary")];
         let rollString = CardinalDiceRoller.copyDicePoolResult(message.rolls?.[0]);
+		console.log("Roll String: " + rollString);
         let directCopy = true;
         let rerollFlavor = "";
         if (rerolltype) {
@@ -147,7 +149,7 @@ export class CardinalDiceRoller {
         }
 
         let roll = await new Roll("{" + rollString + "}cs>" + tni).evaluate({ async: true });
-
+		console.log("Roll Total: " + roll.total);
         const successes = roll.total;
         let highest = 0;
         let ties = 0;
@@ -226,7 +228,7 @@ export class CardinalDiceRoller {
      * @returns {Promise<DiceReturn>} Promise of the roll and the message object or data (depending on sendinchat, true | false) in an object
      */
     static async copyToRollHighest(message, sendinchat = true, rerolltype = "", copyoptions = {}) {
-        if (!(message) || message.type !== CONST.CHAT_MESSAGE_TYPES.ROLL) {
+        if (!(message) || !(message.isRoll)) {
             console.warn("Somehow, a message that isn't a roll got into 'copyToRollHighest'.");
             console.warn(message);
             return;

--- a/module/dicerollers.js
+++ b/module/dicerollers.js
@@ -132,7 +132,6 @@ export class CardinalDiceRoller {
 		const usedSpeaker = (copyoptions.replacespeaker ? { "alias": (message.speaker?.alias ?? game.i18n.localize("ironclaw2e.chatInfo.miniRoll")) } : message.speaker);
         let intermediary = [...message.getFlag("ironclaw2e", "rollIntermediary")];
         let rollString = CardinalDiceRoller.copyDicePoolResult(message.rolls?.[0]);
-		console.log("Roll String: " + rollString);
         let directCopy = true;
         let rerollFlavor = "";
         if (rerolltype) {
@@ -148,9 +147,8 @@ export class CardinalDiceRoller {
             return;
         }
 
-        let roll = await new Roll("{" + rollString + "}cs>" + tni).evaluate({ async: true });
-		console.log("Roll Total: " + roll.total);
-        const successes = roll.total;
+		let roll = message.rolls?.[0];
+		let successes = 0;
         let highest = 0;
         let ties = 0;
         let hasOne = false;
@@ -159,8 +157,9 @@ export class CardinalDiceRoller {
             if (x.result === tni) ties++;
             if (x.result > highest) highest = x.result;
             if (x.result === 1) hasOne = true;
+			if (x.result > tni) successes++;
         });
-
+		
         const flavorstring = CardinalDiceRoller.flavorStringTN(successes, ties, highest, `${(directCopy ? game.i18n.localize("ironclaw2e.chatInfo.copy") : rerollFlavor)} ${game.i18n.localize("ironclaw2e.chatInfo.tn")}:`, label);
 
         /** @type TNData */
@@ -257,8 +256,15 @@ export class CardinalDiceRoller {
             return;
         }
 
-        let roll = await new Roll("{" + rollString + "}kh1").evaluate({ async: true });
-        const flavorstring = CardinalDiceRoller.flavorStringHighest(roll.total, `${(directCopy ? game.i18n.localize("ironclaw2e.chatInfo.copy") : rerollFlavor)} ${game.i18n.localize("ironclaw2e.chatInfo.high")}:`, label);
+        //let roll = await new Roll("{" + rollString + "}kh1").evaluate({ async: true });
+		let roll = message.rolls?.[0];
+		let highest = 0;
+		
+		roll.terms[0].results.forEach(x => {
+		    if (x.result > highest) highest = x.result;
+		});
+		
+        const flavorstring = CardinalDiceRoller.flavorStringHighest(highest, `${(directCopy ? game.i18n.localize("ironclaw2e.chatInfo.copy") : rerollFlavor)} ${game.i18n.localize("ironclaw2e.chatInfo.high")}:`, label);
 
         const hasOne = roll.terms[0].results.some(x => x.result === 1); // Find if one of the dice "rolled" a "1"
 
@@ -270,7 +276,7 @@ export class CardinalDiceRoller {
 
         await CardinalDiceRoller.copyIronclawRollFlags(message, msg);
 
-        return { "roll": roll, "highest": roll.total, "tnData": null, "message": msg, "isSent": sendinchat };
+        return { "roll": roll, "highest": highest, "tnData": null, "message": msg, "isSent": sendinchat };
     }
 
     /**
@@ -606,7 +612,6 @@ export class CardinalDiceRoller {
             // Remove the trailing comma
             formula = formula.slice(0, -1);
         }
-
 
         return formula;
     }

--- a/module/utilitiesmacros.js
+++ b/module/utilitiesmacros.js
@@ -411,10 +411,12 @@ function addIronclawChatLogContext(html, entryOptions) {
                 const message = game.messages.get(li.data("messageId"));
                 const type = message.getFlag("ironclaw2e", "rollType");
                 // Check that the message has a roll, and is not of TN type
-                const allowed = message.type == CONST.CHAT_MESSAGE_TYPES.ROLL && type && type === "HIGH";
-                return allowed && (game.user.isGM || message.isAuthor) && message.isContentVisible;
+                const allowed = message.isRoll && type && type === "HIGH";			
+                return allowed && (game.user.isGM || message.isAuthor) && message.isContentVisible;				
             },
             callback: li => {
+				
+				//console.log("Message ID : " + game.messages.get(li.data("messageId"));
                 const message = game.messages.get(li.data("messageId"));
                 copyToRollTNDialog(message);
             }
@@ -426,7 +428,7 @@ function addIronclawChatLogContext(html, entryOptions) {
                 const message = game.messages.get(li.data("messageId"));
                 const type = message.getFlag("ironclaw2e", "rollType");
                 // Check that the message has a roll, and is of TN type
-                const allowed = message.type == CONST.CHAT_MESSAGE_TYPES.ROLL && type && type === "TN";
+                const allowed = message.isRoll && type && type === "TN";
                 return allowed && (game.user.isGM || message.isAuthor) && message.isContentVisible;
             },
             callback: li => {
@@ -441,7 +443,7 @@ function addIronclawChatLogContext(html, entryOptions) {
                 const message = game.messages.get(li.data("messageId"));
                 const type = message.getFlag("ironclaw2e", "rollType");
                 // Check that the message has a roll, and is not of Highest type
-                const allowed = message.type == CONST.CHAT_MESSAGE_TYPES.ROLL && type && type === "TN";
+                const allowed = message.isRoll && type && type === "TN";
                 return allowed && (game.user.isGM || message.isAuthor) && message.isContentVisible;
             },
             callback: li => {
@@ -458,7 +460,7 @@ function addIronclawChatLogContext(html, entryOptions) {
                 const hasOne = message.getFlag("ironclaw2e", "hasOne");
                 const type = message.getFlag("ironclaw2e", "rollType");
                 // Check that the message has a roll, is rerollable either because it has the new intermediary array stored or because it is the original and has a one
-                const allowed = message.type == CONST.CHAT_MESSAGE_TYPES.ROLL && rerollable && hasOne && type !== "MINI";
+                const allowed = message.isRoll && rerollable && hasOne && type !== "MINI";
                 return allowed && (game.user.isGM || message.isAuthor) && message.isContentVisible;
             },
             callback: li => {
@@ -484,7 +486,7 @@ function addIronclawChatLogContext(html, entryOptions) {
                 const usableRerolls = actor ? actor.getGiftRerollTypes?.(statsUsed, hasOne, message.isAuthor, false)?.size > 0 : game.user.isGM;
                 const type = message.getFlag("ironclaw2e", "rollType");
                 // Check that the message has a roll, is rerollable because it has the new intermediary array stored, and either that the current selected actor has rerolls or the user is a GM
-                const allowed = message.type == CONST.CHAT_MESSAGE_TYPES.ROLL && rerollable && usableRerolls && type !== "MINI";
+                const allowed = message.isRoll && rerollable && usableRerolls && type !== "MINI";
                 return allowed && message.isContentVisible;
             },
             callback: li => {
@@ -504,7 +506,7 @@ function addIronclawChatLogContext(html, entryOptions) {
                 const successes = message.getFlag("ironclaw2e", "attackSuccessCount");
                 const actor = getHangingActor(message);
                 // Check whether the attack effect calculation is active, the message has a roll, has a weapon id and a positive number of successes set and has explicitly been set to have a hanging normal attack
-                const allowed = active && message.type == CONST.CHAT_MESSAGE_TYPES.ROLL && weaponid && successes > 0 && type === "attack";
+                const allowed = active && message.isRoll && weaponid && successes > 0 && type === "attack";
                 return allowed && (game.user.isGM || (message.isAuthor && actor.isOwner)) && message.isContentVisible;
             },
             callback: li => {
@@ -527,7 +529,7 @@ function addIronclawChatLogContext(html, entryOptions) {
                 const successes = message.getFlag("ironclaw2e", "attackSuccessCount");
                 const actor = getHangingActor(message);
                 // Check whether the attack effect calculation is active, the message has a roll, doesn't already have slaying, has a weapon id and a positive number of successes set and has explicitly been set to have a hanging normal attack
-                const allowed = active && message.type == CONST.CHAT_MESSAGE_TYPES.ROLL && !isslaying && weaponid && successes > 0 && type === "attack";
+                const allowed = active && message.isRoll && !isslaying && weaponid && successes > 0 && type === "attack";
                 return allowed && (message.isAuthor && actor.isOwner) && message.isContentVisible;
             },
             callback: li => {
@@ -548,7 +550,7 @@ function addIronclawChatLogContext(html, entryOptions) {
                 const weaponid = message.getFlag("ironclaw2e", "hangingWeapon");
                 const actor = getHangingActor(message);
                 // Check whether the attack effect calculation is active, the message has a roll, has a weapon id set and has explicitly been set to have a hanging counter-attack
-                const allowed = active && message.type == CONST.CHAT_MESSAGE_TYPES.ROLL && weaponid && type === "counter";
+                const allowed = active && message.isRoll && weaponid && type === "counter";
                 return allowed && (message.isAuthor && actor.isOwner) && message.isContentVisible;
             },
             callback: li => {
@@ -570,7 +572,7 @@ function addIronclawChatLogContext(html, entryOptions) {
                 const successes = message.getFlag("ironclaw2e", "resistSuccessCount");
                 const actor = getHangingActor(message);
                 // Check whether the attack effect calculation is active, the message has a roll, has a weapon id and a positive number of successes set and has explicitly been set to have a hanging resist attack
-                const allowed = active && message.type == CONST.CHAT_MESSAGE_TYPES.ROLL && weaponid && successes > 0 && type === "resist";
+                const allowed = active && message.isRoll && weaponid && successes > 0 && type === "resist";
                 return allowed && (message.isAuthor && actor.isOwner) && message.isContentVisible;
             },
             callback: li => {
@@ -592,7 +594,7 @@ function addIronclawChatLogContext(html, entryOptions) {
                 const successes = message.getFlag("ironclaw2e", "resistSuccessCount");
                 const actor = getHangingActor(message);
                 // Check whether the attack effect calculation is active, the message has a roll, has a weapon id and a positive number of successes set and has explicitly been set to have a hanging resist attack
-                const allowed = active && message.type == CONST.CHAT_MESSAGE_TYPES.ROLL && weaponid && successes > 0 && type === "resist";
+                const allowed = active && message.isRoll && weaponid && successes > 0 && type === "resist";
                 return allowed && (message.isAuthor && actor.isOwner) && message.isContentVisible;
             },
             callback: li => {
@@ -615,7 +617,7 @@ function addIronclawChatLogContext(html, entryOptions) {
                 const successes = message.getFlag("ironclaw2e", "resistSuccessCount");
                 const actor = getHangingActor(message);
                 // Check whether the attack effect calculation is active, the message has a roll, doesn't already have slaying, has a weapon id and a positive number of successes set and has explicitly been set to have a hanging resist attack
-                const allowed = active && message.type == CONST.CHAT_MESSAGE_TYPES.ROLL && !isslaying && weaponid && successes > 0 && type === "resist";
+                const allowed = active && message.isRoll && !isslaying && weaponid && successes > 0 && type === "resist";
                 return allowed && (message.isAuthor && actor.isOwner) && message.isContentVisible;
             },
             callback: li => {
@@ -635,7 +637,7 @@ function addIronclawChatLogContext(html, entryOptions) {
                 const messageid = message.getFlag("ironclaw2e", "defenseForAttack");
                 const attackMessage = game.messages.get(messageid);
                 // Check that the message is a roll and that the message has a callback id to the attacker's item info chat message
-                const allowed = message.type == CONST.CHAT_MESSAGE_TYPES.ROLL && attackMessage && type;
+                const allowed = message.isRoll && attackMessage && type;
                 return allowed && (game.user.isGM || attackMessage.isAuthor) && attackMessage.isContentVisible && message.isContentVisible;
             },
             callback: async li => {

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
   "id": "ironclaw2e",
   "title": "Ironclaw Second Edition",
   "description": "Ironclaw Second Edition system for FoundryVTT.",
-  "version": "0.8.1",
+  "version": "#{VERSION}#",
   "minimumCoreVersion": "11",
   "compatibility": {
     "minimum": "11",
@@ -60,8 +60,8 @@
   "secondaryTokenAttribute": "null",
   "url": "https://github.com/Hertzila/Ironclaw2E-FoundryVTT-System",
   "changelog": "https://github.com/Hertzila/Ironclaw2E-FoundryVTT-System/blob/master/CHANGELOG.md",
-  "manifest": "auto-filled",
-  "download": "auto-filled",
+  "manifest": "#{MANIFEST}#",
+  "download": "#{DOWNLOAD}#",
   "license": "LICENSE",
   "readme": "README.md"
 }

--- a/system.json
+++ b/system.json
@@ -9,6 +9,7 @@
     "minimum": "11",
     "verified": "12.330"
   },
+  "templateVersion": 32,
   "authors": [
     {
       "name": "Hertzila",

--- a/system.json
+++ b/system.json
@@ -3,10 +3,10 @@
   "id": "ironclaw2e",
   "title": "Ironclaw Second Edition",
   "description": "Ironclaw Second Edition system for FoundryVTT.",
-  "version": "0.8.1",
-  "minimumCoreVersion": "11",
+  "version": "#{VERSION}#",
+  "minimumCoreVersion": "12",
   "compatibility": {
-    "minimum": "11",
+    "minimum": "12",
     "verified": "12.330"
   },
   "authors": [
@@ -59,8 +59,8 @@
   "secondaryTokenAttribute": "null",
   "url": "https://github.com/Hertzila/Ironclaw2E-FoundryVTT-System",
   "changelog": "https://github.com/Hertzila/Ironclaw2E-FoundryVTT-System/blob/master/CHANGELOG.md",
-  "manifest": "auto-filled",
-  "download": "auto-filled",
+  "manifest": "#{MANIFEST}#",
+  "download": "#{DOWNLOAD}#",
   "license": "LICENSE",
   "readme": "README.md"
 }

--- a/system.json
+++ b/system.json
@@ -9,7 +9,6 @@
     "minimum": "11",
     "verified": "12.330"
   },
-  "templateVersion": 32,
   "authors": [
     {
       "name": "Hertzila",


### PR DESCRIPTION
A few things that changed:

- Instead of using message.type to determine if its a roll, I switched this to message.isRoll
    - This fixed the issue with context menus not appearing as well as re-rolls not triggering
- The Foundry diceroller does not appear to be honoring constant values as a valid roll which was affecting things such as changing TNs and Counter Attacks. It also broke the functionality of switching to "Highest Roll". I was able to work around this with some additional code changes that work.
- Because of the changes (and upcoming API breaking changes) I also removed compatibility with V11.